### PR TITLE
Implement Discord->Minecraft Chat Formatting.

### DIFF
--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -38,6 +38,7 @@ public class ConcordConfig {
 
     public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FONT;
     public static final ForgeConfigSpec.BooleanValue LAZY_TRANSLATIONS;
+    public static final ForgeConfigSpec.BooleanValue USE_LEGACY_FORMATTING;
     public static final ForgeConfigSpec.EnumValue<CrownVisibility> HIDE_CROWN;
 
     public static final ForgeConfigSpec.BooleanValue ALLOW_MENTIONS;
@@ -108,6 +109,11 @@ public class ConcordConfig {
                         "installed.",
                     "Set to false if you cannot ensure that all clients will have the mod installed.")
                 .define("lazy_translate", true);
+
+            USE_LEGACY_FORMATTING = builder.comment("Allow Discord users to put legacy-style chat formatting (&5, etc) in a message.",
+                    "This will cause in-game messages to have color, bold, italic, strikethrough and \"obfuscated\" formatting.",
+                    "Note however, that this only works with vanilla formatting codes, and is likely to cause weirdness.")
+                    .define("use_legacy_formatting", false);
 
             HIDE_CROWN = builder.comment("Configures when the Server Owner crown is visible to clients.",
                     "ALWAYS means the crown is always visible, NEVER means the crown is never visible.",

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -39,6 +39,7 @@ public class ConcordConfig {
     public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FONT;
     public static final ForgeConfigSpec.BooleanValue LAZY_TRANSLATIONS;
     public static final ForgeConfigSpec.BooleanValue USE_LEGACY_FORMATTING;
+    public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FORMATTING;
     public static final ForgeConfigSpec.EnumValue<CrownVisibility> HIDE_CROWN;
 
     public static final ForgeConfigSpec.BooleanValue ALLOW_MENTIONS;
@@ -110,10 +111,18 @@ public class ConcordConfig {
                     "Set to false if you cannot ensure that all clients will have the mod installed.")
                 .define("lazy_translate", true);
 
+            USE_CUSTOM_FORMATTING = builder.comment("Allow Discord users to use Concord Message Formatting Coes in a message.",
+                            "This will cause in-game messages to have color formatting.",
+                            "To use it, send a message with a dollar sign ($) followed by either an English-langauge color (ie. $red), or a hex code (ie. $#FF0000).",
+                            "Names are delimited by a space which will be consumed, so the string \"this is a $red colored text\" will be shown as \"this is a colored text\".",
+                            "Please note that Custom Formatting will override Legacy Formatting when enabled. This is intentional.")
+                    .define("use_custom_formatting", false);
+
             USE_LEGACY_FORMATTING = builder.comment("Allow Discord users to put legacy-style chat formatting (&5, etc) in a message.",
                     "This will cause in-game messages to have color, bold, italic, strikethrough and \"obfuscated\" formatting.",
                     "Note however, that this only works with vanilla formatting codes, and is likely to cause weirdness.")
                     .define("use_legacy_formatting", false);
+
 
             HIDE_CROWN = builder.comment("Configures when the Server Owner crown is visible to clients.",
                     "ALWAYS means the crown is always visible, NEVER means the crown is never visible.",

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -111,9 +111,9 @@ public class ConcordConfig {
                     "Set to false if you cannot ensure that all clients will have the mod installed.")
                 .define("lazy_translate", true);
 
-            USE_CUSTOM_FORMATTING = builder.comment("Allow Discord users to use Concord Message Formatting Coes in a message.",
+            USE_CUSTOM_FORMATTING = builder.comment("Allow Discord users to use Concord Message Formatting Codes in a message.",
                             "This will cause in-game messages to have color formatting.",
-                            "To use it, send a message with a dollar sign ($) followed by either an English-langauge color (ie. $red), or a hex code (ie. $#FF0000).",
+                            "To use it, send a message with a dollar sign ($) followed by either an English-language color (ie. $red), or a hex code (ie. $#FF0000).",
                             "Names are delimited by a space which will be consumed, so the string \"this is a $red colored text\" will be shown as \"this is a colored text\".",
                             "Please note that Custom Formatting will override Legacy Formatting when enabled. This is intentional.")
                     .define("use_custom_formatting", false);

--- a/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
@@ -32,18 +32,12 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
-import net.minecraft.network.chat.ChatType;
-import net.minecraft.network.chat.ClickEvent;
-import net.minecraft.network.chat.ComponentUtils;
-import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextColor;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.*;
 import net.minecraft.network.protocol.game.ClientboundChatPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mutable;
 import tk.sciwhiz12.concord.Concord;
 import tk.sciwhiz12.concord.ConcordConfig;
 import tk.sciwhiz12.concord.ModPresenceTracker;
@@ -130,7 +124,7 @@ public class Messaging {
 
     public static MutableComponent createContentComponent(Message message) {
         final String content = message.getContentDisplay();
-        final MutableComponent text = processMessageFormatting(content);
+        final MutableComponent text = processCustomFormatting(content);
 
         boolean skipSpace = content.length() <= 0 || Character.isWhitespace(content.codePointAt(content.length() - 1));
         for (Message.Attachment attachment : message.getAttachments()) {
@@ -256,7 +250,7 @@ public class Messaging {
      * @return a properly formatted MutableComponent to be echoed into chat.
      * @author Curle
      */
-    private static MutableComponent processMessageFormatting(String input) {
+    private static MutableComponent processLegacyFormatting(String input) {
         if(!ConcordConfig.USE_LEGACY_FORMATTING.get()) {
             // Default to white if legacy formatting is disabled.
             return new TextComponent(input).withStyle(WHITE);
@@ -285,6 +279,80 @@ public class Messaging {
                     currentComponent = currentComponent.append(new TextComponent(part).withStyle(WHITE));
                 }
             }
+
+            return currentComponent;
+        }
+    }
+
+    /**
+     * Search a user-input string for a custom chat formatting syntax.
+     * The custom syntax follows the format of $color or $#hex.
+     * ie. "$red chat" will print "chat" in red. "$#0000FF sup" will print "sup" in blue.
+     * There is no custom formatting for italic, strikethrough, bold, etc.
+     *
+     * @param input the text from Discord
+     * @return a properly formatted MutableComponent to be echoed into chat.
+     * @author Curle
+     */
+    private static MutableComponent processCustomFormatting(String input) {
+        if(!ConcordConfig.USE_CUSTOM_FORMATTING.get()) {
+            // Default to white if custom formatting is disabled.
+            return processLegacyFormatting(input);
+        } else {
+            MutableComponent currentComponent = new TextComponent("");
+            // Regexplanation:
+            // (?= \$ #? [\w \d] + )
+            // ^   ^  ^^ ^ ^ ^   ^ ^
+            // |   |  || | | |   | |
+            // |   |  || | | |   | - End group
+            // |   |  || | | |   - Match at least one
+            // |   |  || | | - Match any digit
+            // |   |  || | - Match any word
+            // |   |  || - Look for any of the following
+            // |   |  |- Match 0 or 1 of the preceding
+            // |   |  - Look for a # character
+            // |   - Look for a $ character
+            // - Include the result in the split strings
+
+            final String[] parts = input.split("(?=\\$#?[\\w\\d]+)");
+
+
+            for (String part : parts) {
+                // Ensure that we only process non-empty strings
+                if (part.isEmpty()) continue;
+
+                final boolean partHasFormatter = part.charAt(0) == '$';
+                final int firstSpacePosition = part.indexOf(' ');
+
+                // Short circuit for strings of only "$" to avoid a temporal paradox
+                if (partHasFormatter && part.length() == 1 && firstSpacePosition == -1) {
+                    currentComponent = currentComponent.append(new TextComponent(part).withStyle(WHITE));
+                    continue;
+                }
+
+                // Make sure that formatting at the end of messages, or lone formatting, is dealt with.
+                final String formatString = firstSpacePosition == -1 ? part.substring(1) : part.substring(1, firstSpacePosition);
+                // Use TextColor's built-in parsing to do the heavy lifting.
+                final TextColor color = TextColor.parseColor(formatString);
+                // Assign the TextColor into a Style instance so that we can use it with a TextComponent.
+                final Style formatting = Style.EMPTY.withColor(color == null ? TextColor.fromLegacyFormat(WHITE) : color);
+
+                if (partHasFormatter && color != null) {
+
+                    currentComponent = currentComponent.append(
+                            // Cut the string on either the space (if there is one) or the end of the string.
+                            new TextComponent(part.substring(firstSpacePosition != -1 ? firstSpacePosition + 1 : part.length()))
+                                    .withStyle(formatting)
+                    );
+                } else {
+                    // White by default!
+                    currentComponent = currentComponent.append(
+                            new TextComponent(part).withStyle(WHITE)
+                    );
+                }
+
+            }
+
 
             return currentComponent;
         }


### PR DESCRIPTION
It's pretty fun to have your messages formatted in-game.

This allows people to send messages in discord with either Legacy style, or Concord style chat formatting sequences, and it will show in-game appropriately.

The custom Concord system i implemented works as follows:
- Every key begins with a $ character
- English-language words can be written after the $ (ie. $red) followed by a space, to apply that formatting in-game
- Hex color codes can be written after the $ (ie. $#FF0000) followed by a space, to apply that formatting in-game

Because it leverages the TextColor parsing system, it does not work with formatting codes, such as bold or italic.

Legacy formatting consists of the old Minecraft section codes, but with an ampersand (&) instead.

A full list of Legacy sequences and the valid english-language color names, for future reference:

   &0: color black
   &1: color dark_blue
   &2: color dark_green
   &3: color dark_aqua
   &4: color dark_red
   &5: color dark_purple
   &6: color gold
   &7: color gray
   &8: color dark_gray
   &9: color blue
   &a: color green
   &b: color aqua
   &c: color red
   &d: color light_purple
   &e: color yellow
   &f: color white
  
   &k: effect obfuscated (makes the letters scrambled and unreadable)
   &l: effect bold
   &m: effect strikethrough (a single thin line through the whole text)
   &n: effect underline
   &o: effect italic
   &r: effect reset (undoes all of the effect formatting)
   
There are two known "issues" with this implementation:
- Formatting cannot be chained; ie, you can't do &l&5 to get bold purple text.
- It looks like ass

They can both be fixed with time, but i wanted to get this code on screen for you to look at.