### PR TITLE
Add Minecraft->Discord user reporting.

### DIFF
--- a/src/data/resources/assets/concord/lang/en_us.json
+++ b/src/data/resources/assets/concord/lang/en_us.json
@@ -20,6 +20,7 @@
   "command.concord.enable": "Enabling discord integration...",
   "command.concord.enable.already_enabled": "Discord integration is already enabled!",
   "command.concord.reload": "Reloading discord integration...",
+  "command.concord.report.status": "Reporting users is %s",
   "command.concord.status": "Discord integration status: %s",
   "command.concord.status.disabled": "DISABLED",
   "command.concord.status.enabled": "ENABLED",

--- a/src/main/java/tk/sciwhiz12/concord/ChatBot.java
+++ b/src/main/java/tk/sciwhiz12/concord/ChatBot.java
@@ -113,16 +113,16 @@ public class ChatBot extends ListenerAdapter {
             return false;
         }
 
-        final GuildChannel channel = guild.getGuildChannelById(ConcordConfig.CHANNEL_ID.get());
+        final GuildChannel channel = guild.getGuildChannelById(ConcordConfig.CHAT_CHANNEL_ID.get());
         if (channel == null) {
             Concord.LOGGER.error(BOT, "There is no channel with ID {} within the guild, as specified in the config.",
-                ConcordConfig.CHANNEL_ID.get());
+                ConcordConfig.CHAT_CHANNEL_ID.get());
             return false;
         }
 
         if (channel.getType() != ChannelType.TEXT) {
             Concord.LOGGER.error(BOT, "The channel with ID {} is not a TEXT channel, it was of type {}.",
-                ConcordConfig.CHANNEL_ID.get(), channel.getType());
+                ConcordConfig.CHAT_CHANNEL_ID.get(), channel.getType());
             return false;
         }
 

--- a/src/main/java/tk/sciwhiz12/concord/Concord.java
+++ b/src/main/java/tk/sciwhiz12/concord/Concord.java
@@ -125,7 +125,7 @@ public class Concord {
         } else if (Strings.isNullOrEmpty(ConcordConfig.GUILD_ID.get())) {
             LOGGER.warn("Guild ID is not set in config; Discord integration will not be enabled.");
             return;
-        } else if (Strings.isNullOrEmpty(ConcordConfig.CHANNEL_ID.get())) {
+        } else if (Strings.isNullOrEmpty(ConcordConfig.CHAT_CHANNEL_ID.get())) {
             LOGGER.warn("Channel ID is not set in config; Discord integration will not be enabled.");
             return;
         }

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -35,7 +35,8 @@ public class ConcordConfig {
 
     public static final ForgeConfigSpec.ConfigValue<String> TOKEN;
     public static final ForgeConfigSpec.ConfigValue<String> GUILD_ID;
-    public static final ForgeConfigSpec.ConfigValue<String> CHANNEL_ID;
+    public static final ForgeConfigSpec.ConfigValue<String> CHAT_CHANNEL_ID;
+    public static final ForgeConfigSpec.ConfigValue<String> REPORT_CHANNEL_ID;
 
     public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FONT;
     public static final ForgeConfigSpec.BooleanValue LAZY_TRANSLATIONS;
@@ -87,9 +88,12 @@ public class ConcordConfig {
             GUILD_ID = builder.comment("The snowflake ID of the guild where this bot belongs to.",
                     "If empty, the Discord integration will not be enabled.")
                 .define("guild_id", "");
-            CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post and receive messages.",
+            CHAT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post and receive messages.",
                     "If empty, the Discord integration will not be enabled.")
-                .define("channel_id", "");
+                .define("chat_channel_id", "");
+            REPORT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post reports from in-game users.",
+                            "If empty, reports will be disabled.")
+                    .define("report_channel_id", "");
 
             builder.pop();
         }

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -175,16 +175,12 @@ public class ConcordCommand {
                             .setColor(0xFF0000)
                             .setDescription("**" + reportedName + "** has been reported by **" + senderName + "**")
                             .addField("Reason", reason, false)
-                            .addField("Location",
-                                    "Reported: **" + reportedName + "**\n" +
+                            .addField("Reported", "**" + reportedName + "** (`" + reportedPlayer.getGameProfile().getId().toString() + "`)\n" +
                                             "Dimension: `" + reportedPlayer.level.dimension().location() + "`\n" +
-                                            "XYZ: " + (int) reportedPlayer.position().x + " " + (int) reportedPlayer.position().y + " " + (int) reportedPlayer.position().z + "\n\n" +
-
-                                            "Reporter: **" + senderName + "**\n" +
+                                            "XYZ: `" + (int) reportedPlayer.position().x + " " + (int) reportedPlayer.position().y + " " + (int) reportedPlayer.position().z + "`", false)
+                            .addField("Reporter", "**" + senderName + "** (`" + sender.getGameProfile().getId().toString() + "`)\n" +
                                             "Dimension: `" + sender.level.dimension().location() + "`\n" +
-                                            "XYZ: " + (int) sender.position().x + " " + (int) sender.position().y + " " + (int) sender.position().z
-                                    , false)
-                            .addField(reportedName + "'s UUID", reportedPlayer.getGameProfile().getId().toString(), false)
+                                            "XYZ: `" + (int) sender.position().x + " " + (int) sender.position().y + " " + (int) sender.position().z + "`", false)
                             .build()
             ).queue();
 

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -133,8 +133,13 @@ public class ConcordCommand {
         // If Concord is disabled for whatever reason, tell the player.
         if (!Concord.isEnabled()) {
             ctx.getSource().sendFailure(
-                    createMessage(ctx.getSource(), "command.concord.status",
-                            createMessage(ctx.getSource(), "command.concord.status.disabled")
+                    resolve(ctx.getSource(),
+                            Translations.COMMAND_REPORT_STATUS
+                                    .component(
+                                            resolve(ctx.getSource(),
+                                                    Translations.COMMAND_STATUS_DISABLED.component()
+                                            )
+                                    )
                     ).withStyle(RED));
             return Command.SINGLE_SUCCESS;
         }
@@ -142,8 +147,13 @@ public class ConcordCommand {
         // If reporting is disabled, also tell the user
         if (ConcordConfig.REPORT_CHANNEL_ID.get().isEmpty()) {
             ctx.getSource().sendFailure(
-                    createMessage(ctx.getSource(), "command.concord.report.status",
-                            createMessage(ctx.getSource(), "command.concord.status.disabled")
+                    resolve(ctx.getSource(),
+                            Translations.COMMAND_REPORT_STATUS
+                                    .component(
+                                            resolve(ctx.getSource(),
+                                                    Translations.COMMAND_STATUS_DISABLED.component()
+                                            )
+                                    )
                     ).withStyle(RED));
             return Command.SINGLE_SUCCESS;
         }
@@ -153,15 +163,25 @@ public class ConcordCommand {
         var bot = Concord.getBot();
         var channel = bot.getDiscord().getTextChannelById(ConcordConfig.REPORT_CHANNEL_ID.get());
 
-        for (ServerPlayer player : players) {
+        if (!players.isEmpty()) {
+            var reportedPlayer = (ServerPlayer) players.toArray()[0];
             channel.sendMessageEmbeds(
                     new EmbedBuilder()
                             .setDescription("A user has been reported!")
                             .addField("",
-                                    "**" + player.getName().getString() + "** has been reported for " + reason, false)
+                                    "**" + reportedPlayer.getName().getString() + "** has been reported for " + reason, false)
                             .build()
             ).queue();
+
+            ctx.getSource().sendSuccess(
+                    resolve(ctx.getSource(),
+                            Translations.COMMAND_REPORT_SUCCESS
+                                    .component(
+                                        reportedPlayer.getName()
+                                    )
+                    ).withStyle(GREEN), true);
         }
+
 
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -159,17 +159,32 @@ public class ConcordCommand {
         }
 
         var players = EntityArgument.getPlayers(ctx, "target");
+        var sender = ctx.getSource().getPlayerOrException();
         var reason = StringArgumentType.getString(ctx, "reason");
         var bot = Concord.getBot();
         var channel = bot.getDiscord().getTextChannelById(ConcordConfig.REPORT_CHANNEL_ID.get());
 
         if (!players.isEmpty()) {
             var reportedPlayer = (ServerPlayer) players.toArray()[0];
+
+            var reportedName = reportedPlayer.getName().getString();
+            var senderName = sender.getName().getString();
             channel.sendMessageEmbeds(
                     new EmbedBuilder()
-                            .setDescription("A user has been reported!")
-                            .addField("",
-                                    "**" + reportedPlayer.getName().getString() + "** has been reported for " + reason, false)
+                            .setAuthor("Concord Integrations")
+                            .setColor(0xFF0000)
+                            .setDescription("**" + reportedName + "** has been reported by **" + senderName + "**")
+                            .addField("Reason", reason, false)
+                            .addField("Location",
+                                    "Reported: **" + reportedName + "**\n" +
+                                            "Dimension: `" + reportedPlayer.level.dimension().location() + "`\n" +
+                                            "XYZ: " + (int) reportedPlayer.position().x + " " + (int) reportedPlayer.position().y + " " + (int) reportedPlayer.position().z + "\n\n" +
+
+                                            "Reporter: **" + senderName + "**\n" +
+                                            "Dimension: `" + sender.level.dimension().location() + "`\n" +
+                                            "XYZ: " + (int) sender.position().x + " " + (int) sender.position().y + " " + (int) sender.position().z
+                                    , false)
+                            .addField(reportedName + "'s UUID", reportedPlayer.getGameProfile().getId().toString(), false)
                             .build()
             ).queue();
 

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -41,6 +41,8 @@ import tk.sciwhiz12.concord.ModPresenceTracker;
 import tk.sciwhiz12.concord.util.TranslationUtil;
 import tk.sciwhiz12.concord.util.Translations;
 
+import java.time.Instant;
+
 import static net.minecraft.ChatFormatting.GREEN;
 import static net.minecraft.ChatFormatting.RED;
 import static net.minecraft.commands.Commands.literal;
@@ -181,6 +183,8 @@ public class ConcordCommand {
                             .addField("Reporter", "**" + senderName + "** (`" + sender.getGameProfile().getId().toString() + "`)\n" +
                                             "Dimension: `" + sender.level.dimension().location() + "`\n" +
                                             "XYZ: `" + (int) sender.position().x + " " + (int) sender.position().y + " " + (int) sender.position().z + "`", false)
+                            .setTimestamp(Instant.now())
+                            .setFooter("Game time: " + sender.level.getGameTime())
                             .build()
             ).queue();
 

--- a/src/main/java/tk/sciwhiz12/concord/msg/MessageListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/MessageListener.java
@@ -56,7 +56,7 @@ public class MessageListener extends ListenerAdapter {
         if (event.isWebhookMessage() || event.getAuthor().isBot()) return; // TODO: maybe make this a config option
 
         if (event.getGuild().getIdLong() == MiscUtil.parseSnowflake(ConcordConfig.GUILD_ID.get()) &&
-            event.getChannel().getIdLong() == MiscUtil.parseSnowflake(ConcordConfig.CHANNEL_ID.get())) {
+            event.getChannel().getIdLong() == MiscUtil.parseSnowflake(ConcordConfig.CHAT_CHANNEL_ID.get())) {
 
             final MessageEntry entry = new MessageEntry(event);
             final MessageReference reference = entry.message.getMessageReference();

--- a/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
@@ -230,7 +230,7 @@ public class Messaging {
     }
 
     public static void sendToChannel(JDA discord, CharSequence text) {
-        final TextChannel channel = discord.getTextChannelById(ConcordConfig.CHANNEL_ID.get());
+        final TextChannel channel = discord.getTextChannelById(ConcordConfig.CHAT_CHANNEL_ID.get());
         if (channel != null) {
             Collection<Message.MentionType> allowedMentions = Collections.emptySet();
             if (ConcordConfig.ALLOW_MENTIONS.get()) {

--- a/src/main/java/tk/sciwhiz12/concord/util/Translations.java
+++ b/src/main/java/tk/sciwhiz12/concord/util/Translations.java
@@ -58,6 +58,8 @@ public enum Translations implements Translation {
     COMMAND_DISABLING("command", "disable", "Disabling discord integration..."),
     COMMAND_ALREADY_DISABLED("command", "disable.already_disabled", "Discord integration is already disabled!"),
     COMMAND_RELOADING("command", "reload", "Reloading discord integration..."),
+    COMMAND_REPORT_STATUS("command", "report.status", "Reporting users is currently %s"),
+    COMMAND_REPORT_SUCCESS("command", "report.success", "A report has been submitted for %s."),
     COMMAND_STATUS_PREFIX("command", "status", "Discord integration status: %s"),
     COMMAND_STATUS_ENABLED("command", "status.enabled", "ENABLED"),
     COMMAND_STATUS_DISABLED("command", "status.disabled", "DISABLED");


### PR DESCRIPTION
A user in-game can use the command:

```
/report <user> <reason>
```

eg. 
```
/report Curle being a nerd
```

and it will send an embed like the following to a configured channel:
![image](https://user-images.githubusercontent.com/42079760/155821101-5c697e3b-344a-45d6-88fc-8f9ba0e6cf3b.png)

The channel is in the config file, and if no channel is set, reporting is disabled.
When reports are disabled, any attempts to use the /report command will tell the player so.

Note that to clear any confusion between the report channel configuration option and the normal chat channel, i renamed the chat option.

This is a breaking change.