### PR TITLE
Add the option of sending chat messages using a webhook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,12 @@ dependencies {
         exclude module: 'slf4j-api'
         exclude module: 'annotations'
     }
-    //library group: 'club.minnced', name: 'discord-webhooks', version: webhook_version
+    library(group: 'club.minnced', name: 'discord-webhooks', version: webhook_version) {
+        exclude module: 'slf4j-api'
+        exclude module: 'annotations'
+        exclude module: 'okhttp'
+        exclude module: 'json'
+    }
 
     dataImplementation sourceSets.main.output
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ dependencies {
         exclude module: 'slf4j-api'
         exclude module: 'annotations'
         exclude module: 'okhttp'
-        exclude module: 'json'
     }
 
     dataImplementation sourceSets.main.output

--- a/src/main/java/tk/sciwhiz12/concord/ChatBot.java
+++ b/src/main/java/tk/sciwhiz12/concord/ChatBot.java
@@ -22,6 +22,7 @@
 
 package tk.sciwhiz12.concord;
 
+import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -49,6 +50,8 @@ import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Icon;
+import net.dv8tion.jda.api.entities.Icon.IconType;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.Message.MentionType;
@@ -66,7 +69,6 @@ public class ChatBot extends ListenerAdapter {
     private static final Marker BOT = MarkerFactory.getMarker("BOT");
     public static final EnumSet<Permission> REQUIRED_PERMISSIONS =
             EnumSet.of(Permission.VIEW_CHANNEL, Permission.MESSAGE_READ, Permission.MESSAGE_WRITE);
-    public static final String MINECRAFT_ICON_URL = "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/favicon-96x96.png";
     public static final String HEAD_URL = "https://crafatar.com/renders/head/%s?default=MHF_Steve&size=128";
     
     private final JDA discord;
@@ -122,12 +124,7 @@ public class ChatBot extends ListenerAdapter {
                     if (textChannel != null) {
                         try {
                             textChannel.createWebhook("Minecraft")
-                                // TODO the line below seems to throw an exception: java.net.SocketException: A
-                                // connection attempt failed because the connected party did not properly
-                                // respond after a period of time, or established connection failed because
-                                // connected host has failed to respond:
-
-                                // .setAvatar(Icon.from(new URL(MINECRAFT_ICON_URL).openStream(), IconType.PNG))
+                                .setAvatar(Icon.from(new URL(discord.getSelfUser().getAvatarUrl()).openStream(), IconType.PNG))
                                 .queue(web -> {
                                     webhook = WebhookClientBuilder.fromJDA(web).setHttpClient(discord.getHttpClient())
                                         .buildJDA();

--- a/src/main/java/tk/sciwhiz12/concord/Concord.java
+++ b/src/main/java/tk/sciwhiz12/concord/Concord.java
@@ -112,7 +112,7 @@ public class Concord {
         if (BOT == null || !isEnabled()) return;
         LOGGER.info("Shutting down Discord integration...");
         if (!suppressMessage) {
-            Messaging.sendToChannel(BOT, Messages.BOT_STOP.component().getString());
+            Messaging.sendToChannel(BOT, Messages.BOT_STOP.component().getString(), null);
         }
         BOT.shutdown();
         BOT = null;

--- a/src/main/java/tk/sciwhiz12/concord/Concord.java
+++ b/src/main/java/tk/sciwhiz12/concord/Concord.java
@@ -112,7 +112,7 @@ public class Concord {
         if (BOT == null || !isEnabled()) return;
         LOGGER.info("Shutting down Discord integration...");
         if (!suppressMessage) {
-            Messaging.sendToChannel(BOT.getDiscord(), Messages.BOT_STOP.component().getString());
+            Messaging.sendToChannel(BOT, Messages.BOT_STOP.component().getString());
         }
         BOT.shutdown();
         BOT = null;

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -92,7 +92,7 @@ public class ConcordConfig {
             GUILD_ID = builder.comment("The snowflake ID of the guild where this bot belongs to.",
                             "If empty, the Discord integration will not be enabled.")
                     .define("guild_id", "");
-            CHAT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will and / or receive messages.",
+            CHAT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post and / or receive messages.",
                             "If empty, the Discord integration will not be enabled.")
                     .define("chat_channel_id", "");
             REPORT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post reports from in-game users.",

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -44,6 +44,7 @@ public class ConcordConfig {
     public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FONT;
     public static final ForgeConfigSpec.BooleanValue LAZY_TRANSLATIONS;
     public static final ForgeConfigSpec.EnumValue<CrownVisibility> HIDE_CROWN;
+    public static final ForgeConfigSpec.BooleanValue SEND_AS_PLAYER;
 
     public static final ForgeConfigSpec.BooleanValue ALLOW_MENTIONS;
     public static final ForgeConfigSpec.BooleanValue ALLOW_PUBLIC_MENTIONS;
@@ -127,6 +128,9 @@ public class ConcordConfig {
                             "WITHOUT_ADMINISTRATORS means it is only visible when there are no hoisted Administrator roles.")
                     .defineEnum("hide_crown", CrownVisibility.WITHOUT_ADMINISTRATORS);
 
+            SEND_AS_PLAYER = builder.comment("If true, messages sent through the webhook (if configured to do so) will use the player's head and username.")
+                    .define("send_as_player", true);
+            
             builder.pop();
         }
 

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -28,6 +28,8 @@ import net.minecraftforge.fml.config.ModConfig;
 import tk.sciwhiz12.concord.util.Messages;
 
 public class ConcordConfig {
+    public static final String GENERATE_WEBHOOK_KEY = "gen";
+    
     static final ForgeConfigSpec CONFIG_SPEC;
 
     public static final ForgeConfigSpec.BooleanValue ENABLE_INTEGRATED;
@@ -37,6 +39,7 @@ public class ConcordConfig {
     public static final ForgeConfigSpec.ConfigValue<String> GUILD_ID;
     public static final ForgeConfigSpec.ConfigValue<String> CHAT_CHANNEL_ID;
     public static final ForgeConfigSpec.ConfigValue<String> REPORT_CHANNEL_ID;
+    public static final ForgeConfigSpec.ConfigValue<String> WEBHOOK_URL;
 
     public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FONT;
     public static final ForgeConfigSpec.BooleanValue LAZY_TRANSLATIONS;
@@ -88,12 +91,17 @@ public class ConcordConfig {
             GUILD_ID = builder.comment("The snowflake ID of the guild where this bot belongs to.",
                             "If empty, the Discord integration will not be enabled.")
                     .define("guild_id", "");
-            CHAT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post and receive messages.",
+            CHAT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will and / or receive messages.",
                             "If empty, the Discord integration will not be enabled.")
                     .define("chat_channel_id", "");
             REPORT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post reports from in-game users.",
                             "If empty, reports will be disabled.")
                     .define("report_channel_id", "");
+            WEBHOOK_URL = builder.comment("The URL of the webhook that the bot will use for sending messages from Minecraft chat.",
+                            "If empty, messages will be sent as the bot.",
+                "A value of \"" + GENERATE_WEBHOOK_KEY
+                    + "\" will make the bot create a webhook in the specified chat channel ID.")
+                    .define("webhook", "");
 
             builder.pop();
         }

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -102,7 +102,7 @@ public class ConcordConfig {
                             "If empty, messages will be sent as the bot.",
                 "A value of \"" + GENERATE_WEBHOOK_KEY
                     + "\" will make the bot create a webhook in the specified chat channel ID.")
-                    .define("webhook", "");
+                .define("webhook", "gen");
 
             builder.pop();
         }

--- a/src/main/java/tk/sciwhiz12/concord/command/SayCommandHook.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/SayCommandHook.java
@@ -26,6 +26,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.logging.LogUtils;
+
 import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.MessageArgument;
@@ -33,6 +34,7 @@ import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.Entity;
+
 import net.minecraftforge.event.RegisterCommandsEvent;
 import org.slf4j.Logger;
 import tk.sciwhiz12.concord.Concord;
@@ -78,7 +80,7 @@ public class SayCommandHook {
     private static void sendMessage(Supplier<String> message) {
         try {
             if (Concord.isEnabled() && ConcordConfig.COMMAND_SAY.get()) {
-                Messaging.sendToChannel(Concord.getBot().getDiscord(), message.get());
+                Messaging.sendToChannel(Concord.getBot(), message.get());
             }
         } catch (Exception e) {
             LOGGER.warn("Exception from command hook; ignoring to continue command execution", e);

--- a/src/main/java/tk/sciwhiz12/concord/command/SayCommandHook.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/SayCommandHook.java
@@ -80,7 +80,7 @@ public class SayCommandHook {
     private static void sendMessage(Supplier<String> message) {
         try {
             if (Concord.isEnabled() && ConcordConfig.COMMAND_SAY.get()) {
-                Messaging.sendToChannel(Concord.getBot(), message.get());
+                Messaging.sendToChannel(Concord.getBot(), message.get(), null);
             }
         } catch (Exception e) {
             LOGGER.warn("Exception from command hook; ignoring to continue command execution", e);

--- a/src/main/java/tk/sciwhiz12/concord/msg/MessageListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/MessageListener.java
@@ -41,7 +41,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class MessageListener extends ListenerAdapter {
-    // Using a concurrent queue because messages is received on a different thread from the main server thread.
+    // Using a concurrent queue because messages are received on a different thread from the main server thread.
     private final Queue<MessageEntry> queuedMessages = new ConcurrentLinkedQueue<>();
     private final ChatBot bot;
 
@@ -80,7 +80,7 @@ public class MessageListener extends ListenerAdapter {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     void onServerChat(ServerChatEvent event) {
-        Messaging.sendToChannel(bot, event.getComponent().getString());
+        Messaging.sendToChannel(bot, event.getComponent().getString().replace("<" + event.getUsername() + ">", ""), event.getPlayer().getGameProfile());
     }
 
     static record MessageEntry(Member member, Message message) {

--- a/src/main/java/tk/sciwhiz12/concord/msg/MessageListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/MessageListener.java
@@ -80,7 +80,7 @@ public class MessageListener extends ListenerAdapter {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     void onServerChat(ServerChatEvent event) {
-        Messaging.sendToChannel(bot.getDiscord(), event.getComponent().getString());
+        Messaging.sendToChannel(bot, event.getComponent().getString());
     }
 
     static record MessageEntry(Member member, Message message) {

--- a/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
@@ -23,6 +23,7 @@
 package tk.sciwhiz12.concord.msg;
 
 import com.google.common.base.Suppliers;
+import com.mojang.authlib.GameProfile;
 
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
@@ -231,7 +232,11 @@ public class Messaging {
         }
     }
 
-    public static void sendToChannel(ChatBot bot, CharSequence text) {
+    public static void sendToChannel(ChatBot bot, CharSequence text, @Nullable GameProfile sender) {
+        sendToChannel(bot, text, sender, true);
+    }
+    
+    public static void sendToChannel(ChatBot bot, CharSequence text, @Nullable GameProfile sender, boolean addSender) {
         Collection<Message.MentionType> allowedMentions = Collections.emptySet();
         if (ConcordConfig.ALLOW_MENTIONS.get()) {
             allowedMentions = EnumSet.noneOf(Message.MentionType.class);
@@ -246,6 +251,6 @@ public class Messaging {
                 allowedMentions.add(Message.MentionType.ROLE);
             }
         }
-        bot.sendMessage(new MessageBuilder(text).setAllowedMentions(allowedMentions).build());
+        bot.sendMessage(text, sender, addSender, allowedMentions);
     }
 }

--- a/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
@@ -23,13 +23,14 @@
 package tk.sciwhiz12.concord.msg;
 
 import com.google.common.base.Suppliers;
-import net.dv8tion.jda.api.JDA;
+
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReference;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.network.chat.ChatType;
@@ -44,6 +45,7 @@ import net.minecraft.network.protocol.game.ClientboundChatPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import tk.sciwhiz12.concord.ChatBot;
 import tk.sciwhiz12.concord.ConcordConfig;
 import tk.sciwhiz12.concord.ModPresenceTracker;
 import tk.sciwhiz12.concord.util.TranslationUtil;
@@ -229,24 +231,21 @@ public class Messaging {
         }
     }
 
-    public static void sendToChannel(JDA discord, CharSequence text) {
-        final TextChannel channel = discord.getTextChannelById(ConcordConfig.CHAT_CHANNEL_ID.get());
-        if (channel != null) {
-            Collection<Message.MentionType> allowedMentions = Collections.emptySet();
-            if (ConcordConfig.ALLOW_MENTIONS.get()) {
-                allowedMentions = EnumSet.noneOf(Message.MentionType.class);
-                if (ConcordConfig.ALLOW_PUBLIC_MENTIONS.get()) {
-                    allowedMentions.add(Message.MentionType.EVERYONE);
-                    allowedMentions.add(Message.MentionType.HERE);
-                }
-                if (ConcordConfig.ALLOW_USER_MENTIONS.get()) {
-                    allowedMentions.add(Message.MentionType.USER);
-                }
-                if (ConcordConfig.ALLOW_ROLE_MENTIONS.get()) {
-                    allowedMentions.add(Message.MentionType.ROLE);
-                }
+    public static void sendToChannel(ChatBot bot, CharSequence text) {
+        Collection<Message.MentionType> allowedMentions = Collections.emptySet();
+        if (ConcordConfig.ALLOW_MENTIONS.get()) {
+            allowedMentions = EnumSet.noneOf(Message.MentionType.class);
+            if (ConcordConfig.ALLOW_PUBLIC_MENTIONS.get()) {
+                allowedMentions.add(Message.MentionType.EVERYONE);
+                allowedMentions.add(Message.MentionType.HERE);
             }
-            channel.sendMessage(text).allowedMentions(allowedMentions).queue();
+            if (ConcordConfig.ALLOW_USER_MENTIONS.get()) {
+                allowedMentions.add(Message.MentionType.USER);
+            }
+            if (ConcordConfig.ALLOW_ROLE_MENTIONS.get()) {
+                allowedMentions.add(Message.MentionType.ROLE);
+            }
         }
+        bot.sendMessage(new MessageBuilder(text).setAllowedMentions(allowedMentions).build());
     }
 }

--- a/src/main/java/tk/sciwhiz12/concord/msg/PlayerListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/PlayerListener.java
@@ -53,7 +53,7 @@ public class PlayerListener {
 
         TranslatableComponent text = Messages.PLAYER_JOIN.component(event.getPlayer().getDisplayName());
 
-        Messaging.sendToChannel(bot, text.getString());
+        Messaging.sendToChannel(bot, text.getString(), event.getPlayer().getGameProfile(), false);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -63,7 +63,7 @@ public class PlayerListener {
 
         TranslatableComponent text = Messages.PLAYER_LEAVE.component(event.getPlayer().getDisplayName());
 
-        Messaging.sendToChannel(bot, text.getString());
+        Messaging.sendToChannel(bot, text.getString(), event.getPlayer().getGameProfile(), false);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -72,7 +72,7 @@ public class PlayerListener {
         if (!ConcordConfig.PLAYER_DEATH.get()) return;
 
         if (event.getEntity() instanceof ServerPlayer player) {
-            Messaging.sendToChannel(bot, player.getCombatTracker().getDeathMessage().getString());
+            Messaging.sendToChannel(bot, player.getCombatTracker().getDeathMessage().getString(), player.getGameProfile(), false);
         }
     }
 
@@ -102,7 +102,7 @@ public class PlayerListener {
                     info.getTitle(),
                     info.getDescription());
 
-            Messaging.sendToChannel(bot, text.getString());
+            Messaging.sendToChannel(bot, text.getString(), null);
         }
     }
 }

--- a/src/main/java/tk/sciwhiz12/concord/msg/PlayerListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/PlayerListener.java
@@ -53,7 +53,7 @@ public class PlayerListener {
 
         TranslatableComponent text = Messages.PLAYER_JOIN.component(event.getPlayer().getDisplayName());
 
-        Messaging.sendToChannel(bot.getDiscord(), text.getString());
+        Messaging.sendToChannel(bot, text.getString());
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -63,7 +63,7 @@ public class PlayerListener {
 
         TranslatableComponent text = Messages.PLAYER_LEAVE.component(event.getPlayer().getDisplayName());
 
-        Messaging.sendToChannel(bot.getDiscord(), text.getString());
+        Messaging.sendToChannel(bot, text.getString());
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -72,7 +72,7 @@ public class PlayerListener {
         if (!ConcordConfig.PLAYER_DEATH.get()) return;
 
         if (event.getEntity() instanceof ServerPlayer player) {
-            Messaging.sendToChannel(bot.getDiscord(), player.getCombatTracker().getDeathMessage().getString());
+            Messaging.sendToChannel(bot, player.getCombatTracker().getDeathMessage().getString());
         }
     }
 
@@ -102,7 +102,7 @@ public class PlayerListener {
                     info.getTitle(),
                     info.getDescription());
 
-            Messaging.sendToChannel(bot.getDiscord(), text.getString());
+            Messaging.sendToChannel(bot, text.getString());
         }
     }
 }

--- a/src/main/java/tk/sciwhiz12/concord/msg/StatusListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/StatusListener.java
@@ -43,13 +43,13 @@ public class StatusListener {
     void onServerStarted(ServerStartedEvent event) {
         if (!ConcordConfig.SERVER_START.get()) return;
 
-        Messaging.sendToChannel(bot, Messages.SERVER_START.component().getString());
+        Messaging.sendToChannel(bot, Messages.SERVER_START.component().getString(), null);
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)
     void onServerStopping(ServerStoppingEvent event) {
         if (!ConcordConfig.SERVER_STOP.get()) return;
 
-        Messaging.sendToChannel(bot, Messages.SERVER_STOP.component().getString());
+        Messaging.sendToChannel(bot, Messages.SERVER_STOP.component().getString(), null);
     }
 }

--- a/src/main/java/tk/sciwhiz12/concord/msg/StatusListener.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/StatusListener.java
@@ -43,13 +43,13 @@ public class StatusListener {
     void onServerStarted(ServerStartedEvent event) {
         if (!ConcordConfig.SERVER_START.get()) return;
 
-        Messaging.sendToChannel(bot.getDiscord(), Messages.SERVER_START.component().getString());
+        Messaging.sendToChannel(bot, Messages.SERVER_START.component().getString());
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)
     void onServerStopping(ServerStoppingEvent event) {
         if (!ConcordConfig.SERVER_STOP.get()) return;
 
-        Messaging.sendToChannel(bot.getDiscord(), Messages.SERVER_STOP.component().getString());
+        Messaging.sendToChannel(bot, Messages.SERVER_STOP.component().getString());
     }
 }


### PR DESCRIPTION
This PR adds the option of sending the chat messages in Discord through a webhook. The URL of the webhook is configurable, but it can also be setup to generate a new webhook.
Messages can now also be sent using the webhook, with the name and avatar of a Minecraft player.