### PR TITLE
Implement support ticketing

### DIFF
--- a/src/main/java/tk/sciwhiz12/concord/ChatBot.java
+++ b/src/main/java/tk/sciwhiz12/concord/ChatBot.java
@@ -26,10 +26,7 @@ import com.google.common.collect.Sets;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.entities.ChannelType;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.utils.messages.MessageRequest;
@@ -141,4 +138,17 @@ public class ChatBot extends ListenerAdapter {
         // Required permissions are there. All checks satisfied.
         return true;
     }
+
+    public TextChannel getChatChannel() {
+        checkSatisfaction();
+        final Guild guild = discord.getGuildById(ConcordConfig.GUILD_ID.get());
+        return (TextChannel) guild.getGuildChannelById(ConcordConfig.CHAT_CHANNEL_ID.get());
+    }
+
+    public TextChannel getReportChannel() {
+        checkSatisfaction();
+        final Guild guild = discord.getGuildById(ConcordConfig.GUILD_ID.get());
+        return (TextChannel) guild.getGuildChannelById(ConcordConfig.REPORT_CHANNEL_ID.get());
+    }
+
 }

--- a/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
+++ b/src/main/java/tk/sciwhiz12/concord/ConcordConfig.java
@@ -42,6 +42,8 @@ public class ConcordConfig {
     public static final ForgeConfigSpec.ConfigValue<String> CHAT_CHANNEL_ID;
     public static final ForgeConfigSpec.ConfigValue<String> REPORT_CHANNEL_ID;
 
+    public static final ForgeConfigSpec.ConfigValue<String> MODERATOR_ROLE_ID;
+
     public static final ForgeConfigSpec.BooleanValue USE_CUSTOM_FONT;
     public static final ForgeConfigSpec.BooleanValue LAZY_TRANSLATIONS;
     public static final ForgeConfigSpec.EnumValue<CrownVisibility> HIDE_CROWN;
@@ -110,6 +112,11 @@ public class ConcordConfig {
             REPORT_CHANNEL_ID = builder.comment("The snowflake ID of the channel where this bot will post reports from in-game users.",
                             "If empty, reports will be disabled.")
                     .define("report_channel_id", "");
+
+            MODERATOR_ROLE_ID = builder.comment("The snowflake ID of the role that will be treated as a moderator role.",
+                            "This role will be able to use Concord's Moderation slash commands on Discord - /kick, /ban, etc.",
+                            "This should not be treated as an alternative to proper Discord permissions configuration, but exists as a safeguard so that random users may not ban you while you're setting up.")
+                    .define("moderator_role_id", "");
 
             builder.pop();
         }

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -119,14 +119,10 @@ public class ConcordCommand {
             // We need to ping the moderators, and we can't do it from an embed, and we can't ping anyone unless it's explicitly told to, so..
             // Send the message with the mention
             Concord.BOT.getReportChannel().sendMessage("<@&" + ConcordConfig.MODERATOR_ROLE_ID.get() + ">")
-                    // Enable role mentions for just this message
-                    .allowedMentions(
+                    .setAllowedMentions(
                             Collections.singleton(Message.MentionType.ROLE)
                     )
-                    // Allow the moderator role to be the one mentioned, for just this message
-                    .mentionRoles(
-                            ConcordConfig.MODERATOR_ROLE_ID.get()
-                    )
+                    .mentionRoles(ConcordConfig.MODERATOR_ROLE_ID.get())
                     // And set context too.
                     .setEmbeds(new EmbedBuilder()
                             .setTitle("Support Requst")

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -126,17 +126,15 @@ public class ConcordCommand {
                     // Allow the moderator role to be the one mentioned, for just this message
                     .mentionRoles(
                             ConcordConfig.MODERATOR_ROLE_ID.get()
-                    ).queue();
-            // Send the embed too
-            Concord.BOT.getReportChannel().sendMessageEmbeds(
-                    new EmbedBuilder()
+                    )
+                    // And set context too.
+                    .setEmbeds(new EmbedBuilder()
                             .setTitle("Support Requst")
                             .setDescription("A user has requested the support of a Server Administrator!")
                             .addField("User", source.getTextName(), false)
                             .setTimestamp(Instant.now())
                             .setColor(Color.ORANGE)
-                            .build()
-            ).queue();
+                            .build()).queue();
 
             ctx.getSource().sendSuccess(Translations.COMMAND_SUPPORT_SUCCESS.resolvedComponent(source), false);
         } else {

--- a/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ConcordCommand.java
@@ -24,12 +24,19 @@ package tk.sciwhiz12.concord.command;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import tk.sciwhiz12.concord.Concord;
+import tk.sciwhiz12.concord.ConcordConfig;
 import tk.sciwhiz12.concord.util.Translations;
+
+import java.awt.*;
+import java.time.Instant;
+import java.util.Collections;
 
 import static net.minecraft.ChatFormatting.GREEN;
 import static net.minecraft.ChatFormatting.RED;
@@ -54,6 +61,9 @@ public class ConcordCommand {
                         )
                         .then(literal("status")
                                 .executes(ConcordCommand::status)
+                        )
+                        .then(literal("support")
+                                .executes(ConcordCommand::support)
                         )
         );
     }
@@ -99,6 +109,40 @@ public class ConcordCommand {
             result = Translations.COMMAND_STATUS_DISABLED.resolvedComponent(source).withStyle(RED);
         }
         ctx.getSource().sendSuccess(Translations.COMMAND_STATUS_PREFIX.resolvedComponent(source, result), false);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int support(CommandContext<CommandSourceStack> ctx) {
+        CommandSourceStack source = ctx.getSource();
+
+        if (Concord.isEnabled() && !ConcordConfig.MODERATOR_ROLE_ID.get().isEmpty()) {
+            // We need to ping the moderators, and we can't do it from an embed, and we can't ping anyone unless it's explicitly told to, so..
+            // Send the message with the mention
+            Concord.BOT.getReportChannel().sendMessage("<@&" + ConcordConfig.MODERATOR_ROLE_ID.get() + ">")
+                    // Enable role mentions for just this message
+                    .allowedMentions(
+                            Collections.singleton(Message.MentionType.ROLE)
+                    )
+                    // Allow the moderator role to be the one mentioned, for just this message
+                    .mentionRoles(
+                            ConcordConfig.MODERATOR_ROLE_ID.get()
+                    ).queue();
+            // Send the embed too
+            Concord.BOT.getReportChannel().sendMessageEmbeds(
+                    new EmbedBuilder()
+                            .setTitle("Support Requst")
+                            .setDescription("A user has requested the support of a Server Administrator!")
+                            .addField("User", source.getTextName(), false)
+                            .setTimestamp(Instant.now())
+                            .setColor(Color.ORANGE)
+                            .build()
+            ).queue();
+
+            ctx.getSource().sendSuccess(Translations.COMMAND_SUPPORT_SUCCESS.resolvedComponent(source), false);
+        } else {
+            ctx.getSource().sendSuccess(Translations.COMMAND_SUPPORT_DISABLED.resolvedComponent(source), false);
+        }
+
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/tk/sciwhiz12/concord/util/Translations.java
+++ b/src/main/java/tk/sciwhiz12/concord/util/Translations.java
@@ -66,6 +66,7 @@ public enum Translations implements Translation {
 
     COMMAND_SUPPORT_DISABLED("command", "support.disabled", "1.1.0", "Sorry, but Concord is currently disabled, you may not send a support ticket at this time."),
     COMMAND_SUPPORT_SUCCESS("command", "support.success", "1.1.0", "Support Ticket sent successfully."),
+    COMMAND_SUPPORT_NO_REASON("command", "support.noreason", "1.1.0", "No Reason Provided"),
     COMMAND_STATUS_PREFIX("command", "status", "1.0.0", "Discord integration status: %s"),
     COMMAND_STATUS_ENABLED("command", "status.enabled", "1.0.0", "ENABLED"),
     COMMAND_STATUS_DISABLED("command", "status.disabled", "1.0.0", "DISABLED");

--- a/src/main/java/tk/sciwhiz12/concord/util/Translations.java
+++ b/src/main/java/tk/sciwhiz12/concord/util/Translations.java
@@ -63,6 +63,9 @@ public enum Translations implements Translation {
     COMMAND_RELOADING("command", "reload", "1.0.0", "Reloading discord integration..."),
     COMMAND_REPORT_STATUS("command", "report.status", "1.1.0", "Reporting users is currently %s"),
     COMMAND_REPORT_SUCCESS("command", "report.success", "1.1.0", "Submitted report for %s for reason: %s"),
+
+    COMMAND_SUPPORT_DISABLED("command", "support.disabled", "1.1.0", "Sorry, but Concord is currently disabled, you may not send a support ticket at this time."),
+    COMMAND_SUPPORT_SUCCESS("command", "support.success", "1.1.0", "Support Ticket sent successfully."),
     COMMAND_STATUS_PREFIX("command", "status", "1.0.0", "Discord integration status: %s"),
     COMMAND_STATUS_ENABLED("command", "status.enabled", "1.0.0", "ENABLED"),
     COMMAND_STATUS_DISABLED("command", "status.disabled", "1.0.0", "DISABLED");


### PR DESCRIPTION
Adds a /concord support command that simply pings server administrators and tells them that a user needs help.

TODO: 
Add an optional message to be sent along for context.