### PR TITLE
Implement thread support

### DIFF
--- a/src/main/java/tk/sciwhiz12/concord/ChatBot.java
+++ b/src/main/java/tk/sciwhiz12/concord/ChatBot.java
@@ -120,8 +120,9 @@ public class ChatBot extends ListenerAdapter {
             return false;
         }
 
-        if (channel.getType() != ChannelType.TEXT && channel.getType() != ChannelType.GUILD_PUBLIC_THREAD) {
-            Concord.LOGGER.error(BOT, "The channel with ID {} is not a TEXT channel or public thread, it was of type {}.",
+        if (channel.getType() != ChannelType.TEXT && channel.getType() != ChannelType.GUILD_PUBLIC_THREAD &&
+            channel.getType() != ChannelType.GUILD_PRIVATE_THREAD) {
+            Concord.LOGGER.error(BOT, "The channel with ID {} is not a TEXT channel or non-announcement thread, it was of type {}.",
                     ConcordConfig.CHAT_CHANNEL_ID.get(), channel.getType());
             return false;
         }
@@ -129,7 +130,7 @@ public class ChatBot extends ListenerAdapter {
         // Guild and channel IDs are correct, now to check permissions
 
         // If the channel is a thread, also require thread message send permissions
-        if (channel.getType() == ChannelType.GUILD_PUBLIC_THREAD) {
+        if (channel.getType().isThread()) {
             REQUIRED_PERMISSIONS.add(Permission.MESSAGE_SEND_IN_THREADS);
         }
 

--- a/src/main/java/tk/sciwhiz12/concord/ChatBot.java
+++ b/src/main/java/tk/sciwhiz12/concord/ChatBot.java
@@ -120,13 +120,19 @@ public class ChatBot extends ListenerAdapter {
             return false;
         }
 
-        if (channel.getType() != ChannelType.TEXT) {
-            Concord.LOGGER.error(BOT, "The channel with ID {} is not a TEXT channel, it was of type {}.",
+        if (channel.getType() != ChannelType.TEXT && channel.getType() != ChannelType.GUILD_PUBLIC_THREAD) {
+            Concord.LOGGER.error(BOT, "The channel with ID {} is not a TEXT channel or public thread, it was of type {}.",
                     ConcordConfig.CHAT_CHANNEL_ID.get(), channel.getType());
             return false;
         }
 
         // Guild and channel IDs are correct, now to check permissions
+
+        // If the channel is a thread, also require thread message send permissions
+        if (channel.getType() == ChannelType.GUILD_PUBLIC_THREAD) {
+            REQUIRED_PERMISSIONS.add(Permission.MESSAGE_SEND_IN_THREADS);
+        }
+
         final Sets.SetView<Permission> missingPermissions = Sets
                 .difference(REQUIRED_PERMISSIONS, guild.getSelfMember().getPermissions(channel));
 

--- a/src/main/java/tk/sciwhiz12/concord/ChatBot.java
+++ b/src/main/java/tk/sciwhiz12/concord/ChatBot.java
@@ -121,8 +121,9 @@ public class ChatBot extends ListenerAdapter {
         }
 
         if (channel.getType() != ChannelType.TEXT && channel.getType() != ChannelType.GUILD_PUBLIC_THREAD &&
-            channel.getType() != ChannelType.GUILD_PRIVATE_THREAD) {
-            Concord.LOGGER.error(BOT, "The channel with ID {} is not a TEXT channel or non-announcement thread, it was of type {}.",
+                channel.getType() != ChannelType.GUILD_PRIVATE_THREAD) {
+            Concord.LOGGER.error(BOT,
+                    "The channel with ID {} is not a TEXT channel or non-announcement thread, it was of type {}.",
                     ConcordConfig.CHAT_CHANNEL_ID.get(), channel.getType());
             return false;
         }

--- a/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
@@ -27,6 +27,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import net.minecraft.commands.CommandSourceStack;
@@ -84,10 +85,10 @@ public class ReportCommand {
 
         boolean sendingAllowed = false;
         if (channel != null && (channel.getType() == ChannelType.TEXT || channel.getType() == ChannelType.GUILD_PUBLIC_THREAD)) {
-            sendingAllowed = channel.canTalk();
+            sendingAllowed = channel.canTalk() && channel.getGuild().getSelfMember().hasPermission(channel, Permission.MESSAGE_EMBED_LINKS);
         }
 
-        // If reporting is disabled, also tell the user
+        // If reporting is disabled or not possible, also tell the user
         if (!sendingAllowed) {
             ctx.getSource().sendFailure(
                     Translations.COMMAND_REPORT_STATUS.resolvedComponent(ctx.getSource(),

--- a/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
@@ -84,7 +84,8 @@ public class ReportCommand {
         final GuildMessageChannel channel = channelID.isBlank() ? null : bot.getDiscord().getChannelById(GuildMessageChannel.class, channelID);
 
         boolean sendingAllowed = false;
-        if (channel != null && (channel.getType() == ChannelType.TEXT || channel.getType() == ChannelType.GUILD_PUBLIC_THREAD)) {
+        if (channel != null && (channel.getType() == ChannelType.TEXT || channel.getType() == ChannelType.GUILD_PUBLIC_THREAD ||
+                                channel.getType() == ChannelType.GUILD_PRIVATE_THREAD)) {
             sendingAllowed = channel.canTalk() && channel.getGuild().getSelfMember().hasPermission(channel, Permission.MESSAGE_EMBED_LINKS);
         }
 

--- a/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
@@ -81,12 +81,15 @@ public class ReportCommand {
 
         final ChatBot bot = Concord.getBot();
         final String channelID = ConcordConfig.REPORT_CHANNEL_ID.get();
-        final GuildMessageChannel channel = channelID.isBlank() ? null : bot.getDiscord().getChannelById(GuildMessageChannel.class, channelID);
+        final GuildMessageChannel channel = channelID.isBlank() ? null :
+                bot.getDiscord().getChannelById(GuildMessageChannel.class, channelID);
 
+        // Check permissions and channel type to see if sending is allowed
         boolean sendingAllowed = false;
         if (channel != null && (channel.getType() == ChannelType.TEXT || channel.getType() == ChannelType.GUILD_PUBLIC_THREAD ||
-                                channel.getType() == ChannelType.GUILD_PRIVATE_THREAD)) {
-            sendingAllowed = channel.canTalk() && channel.getGuild().getSelfMember().hasPermission(channel, Permission.MESSAGE_EMBED_LINKS);
+                channel.getType() == ChannelType.GUILD_PRIVATE_THREAD)) {
+            sendingAllowed = channel.canTalk() && channel.getGuild().getSelfMember()
+                    .hasPermission(channel, Permission.MESSAGE_EMBED_LINKS);
         }
 
         // If reporting is disabled or not possible, also tell the user

--- a/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
+++ b/src/main/java/tk/sciwhiz12/concord/command/ReportCommand.java
@@ -27,7 +27,8 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.core.BlockPos;
@@ -79,10 +80,15 @@ public class ReportCommand {
 
         final ChatBot bot = Concord.getBot();
         final String channelID = ConcordConfig.REPORT_CHANNEL_ID.get();
-        final TextChannel channel = channelID.isBlank() ? null : bot.getDiscord().getTextChannelById(channelID);
+        final GuildMessageChannel channel = channelID.isBlank() ? null : bot.getDiscord().getChannelById(GuildMessageChannel.class, channelID);
+
+        boolean sendingAllowed = false;
+        if (channel != null && (channel.getType() == ChannelType.TEXT || channel.getType() == ChannelType.GUILD_PUBLIC_THREAD)) {
+            sendingAllowed = channel.canTalk();
+        }
 
         // If reporting is disabled, also tell the user
-        if (channel == null) {
+        if (!sendingAllowed) {
             ctx.getSource().sendFailure(
                     Translations.COMMAND_REPORT_STATUS.resolvedComponent(ctx.getSource(),
                             Translations.COMMAND_STATUS_DISABLED.resolvedComponent(ctx.getSource())

--- a/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
@@ -25,7 +25,7 @@ package tk.sciwhiz12.concord.msg;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import net.dv8tion.jda.api.entities.sticker.StickerItem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.locale.Language;
@@ -244,7 +244,8 @@ public class Messaging {
     }
 
     public static void sendToChannel(JDA discord, CharSequence text) {
-        final TextChannel channel = discord.getTextChannelById(ConcordConfig.CHAT_CHANNEL_ID.get());
+        final GuildMessageChannel channel = discord.getChannelById(GuildMessageChannel.class,
+                                                                   ConcordConfig.CHAT_CHANNEL_ID.get());
         if (channel != null) {
             Collection<Message.MentionType> allowedMentions = Collections.emptySet();
             if (ConcordConfig.ALLOW_MENTIONS.get()) {

--- a/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
+++ b/src/main/java/tk/sciwhiz12/concord/msg/Messaging.java
@@ -245,7 +245,7 @@ public class Messaging {
 
     public static void sendToChannel(JDA discord, CharSequence text) {
         final GuildMessageChannel channel = discord.getChannelById(GuildMessageChannel.class,
-                                                                   ConcordConfig.CHAT_CHANNEL_ID.get());
+                ConcordConfig.CHAT_CHANNEL_ID.get());
         if (channel != null) {
             Collection<Message.MentionType> allowedMentions = Collections.emptySet();
             if (ConcordConfig.ALLOW_MENTIONS.get()) {


### PR DESCRIPTION
Adds the ability to use the IDs of threads as the channel ID.
Works with both public and private threads, although private threads need the bot to be added manually in Discord.
The selected thread also can't be archived, as this will cause JDA to not be able to find the channel.

Both issues may be circumvented with further permissions, but I did not want to add those as a requirement, so I did not further look into how exactly it could be done.